### PR TITLE
Use absolute paths for DAGMC model

### DIFF
--- a/openmc_weight_window_generator/core.py
+++ b/openmc_weight_window_generator/core.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pathlib import Path
 
 from copy import deepcopy
 
@@ -146,6 +147,11 @@ class Model(openmc.Model):
         # check_tally(model, tally_id)
 
         cwd_stub = Path(output_dir)
+
+        # expand dagmc paths if needed
+        for univ in self.geometry.get_all_universes().values():
+            if isinstance(univ, openmc.DAGMCUniverse):
+                univ.filename = Path(univ.filename).absolute()
 
         # if comm.rank == 0:
             # print('comm rank is 0 so exporting xml')


### PR DESCRIPTION
Expands file paths of DAGMC universes to an absolute path so that the model file can always be found.